### PR TITLE
Step2 최적화 및 사용성 개선

### DIFF
--- a/src/app/(mood)/join/funnels/step2/components/MoodBoard.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/MoodBoard.tsx
@@ -7,6 +7,7 @@ import { useJoin1Context } from '../../../components/Join1Context';
 import { useWatch } from 'react-hook-form';
 import { motion } from 'framer-motion';
 import { fadeInOut } from '@/constants';
+import usePreloadImages from '@/hooks/usePreloadImage';
 
 export default function MoodBoard() {
   const { theme } = useTheme();
@@ -17,6 +18,13 @@ export default function MoodBoard() {
     control,
     name: 'gender',
   }).toLowerCase();
+
+  usePreloadImages([
+    '/image/light-male-profile.png',
+    '/image/light-female-profile.png',
+    '/image/dark-female-profile.png',
+    '/image/dark-male-profile.png',
+  ]);
 
   return (
     <div className="-z-50 mx-auto mb-6 mt-8 flex h-52 flex-col items-center justify-center gap-y-6">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,17 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import Providers from '@/providers/Providers';
 
 export const metadata: Metadata = {
   title: 'Gyeol | 결',
   description: 'Gyeol, 결',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function RootLayout({ children }: PropsWithStrictChildren) {

--- a/src/hooks/usePreloadImage.ts
+++ b/src/hooks/usePreloadImage.ts
@@ -1,0 +1,12 @@
+import { useLayoutEffect } from 'react';
+
+const usePreloadImage = (images: string[]) => {
+  useLayoutEffect(() => {
+    images.forEach((image) => {
+      const img = new Image();
+      img.src = image;
+    });
+  }, []);
+};
+
+export default usePreloadImage;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #53 

## 📝 작업 내용
- 이미지를 pre-load 합니다.

![화면 기록 2024-03-06 오전 12 09 00](https://github.com/forfun-flowing/frontend/assets/48711263/c58d68f0-698d-4f8b-9a50-6dbeb23c2652)
보이는 것처럼 남/여 버튼 혹은 토글 버튼을 **'눌렀을 때'** 이미지를 불러오게 됩니다. 따라서 의도했던 애니메이션이 적용되지 않는 문제가 있어서 Step2에서 필요한 이미지 4개를 미리 불러오도록 구현했습니다.

- viewport 태그를 적용해서 모바일 환경에서 인풋을 눌렀을 때 확대되지 않도록 적용했습니다.
## 💬 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
