### PR TITLE
Axios interceptors request 로직으로 인해 API 요청이 가지 않는 문제를 해결한다

### DIFF
--- a/src/apis/config/instance.ts
+++ b/src/apis/config/instance.ts
@@ -12,9 +12,13 @@ const instance = axios.create({
 
 instance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig<any>) => {
-    const { cookies } = await import('next/headers');
-    const token = cookies().get('accessToken');
-    if (token) config.headers.Authorization = `Bearer ${token}`;
+    try {
+      const { cookies } = await import('next/headers');
+      const token = cookies().get('accessToken');
+      config.headers.Authorization = `Bearer ${token}`;
+    } catch (error) {
+      console.log('쿠키가 없음: ', error);
+    }
 
     return config;
   },

--- a/src/apis/config/instance.ts
+++ b/src/apis/config/instance.ts
@@ -17,7 +17,7 @@ instance.interceptors.request.use(
       const token = cookies().get('accessToken');
       config.headers.Authorization = `Bearer ${token}`;
     } catch (error) {
-      console.log('쿠키가 없음: ', error);
+      console.log(error);
     }
 
     return config;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #66 


## 📝 작업 내용
react-query devtools에서는 Fetching 상태로 계속 유지되나, 네트워크 탭에서 http 요청이 가지 않음을 알 수 있었고 알 수 없는 이유로 API 요청이 가지를 않았습니다. 문제를 재현하면서 범위를 좁혀나갔고 쿠키가 없을 때 **Axios interceptors**의 요청을 가로채는 로직에서 문제가 생겼음을 발견했습니다. 그래서 다음과 같이 `try~catch`로 쿠키가 없을 때의 에러를 핸들링 해주었습니다.

``` tsx
instance.interceptors.request.use(
  async (config: InternalAxiosRequestConfig<any>) => {
    try {
      const { cookies } = await import('next/headers');
      const token = cookies().get('accessToken');
      config.headers.Authorization = `Bearer ${token}`;
    } catch (error) {
      console.log(error);
    }

    return config;
  },
  (error) => {
    return Promise.reject(error);
  },
);
```

## 💬 리뷰어에게

저희 서비스가 로그인을 제외하고 모두 로그인 권한이 필요한 API들이여서 인스턴스를 만들 때부터 private/public Instance로 나누진 않았거든요. 추후에 상황 보고 구분이 필요하다면 나누는 것도 괜찮아보입니다!
