### PR TITLE
prettier-plugin-tailwindcss가 적용되지 않는 문제를 해결한다.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,12 +5,8 @@
   "tabWidth": 2,
   "trailingComma": "all",
   "printWidth": 100,
-  "plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],
-  "importOrder": [
-    "<THIRD_PARTY_MODULES>", 
-    "^@/",
-    "^[./]"
-  ],
+  "plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"],
+  "importOrder": ["<THIRD_PARTY_MODULES>", "^@/", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "postcss": "^8",
     "prettier": "^3.1.1",
     "prettier-plugin-tailwindcss": "0.4.1",
-    "sb": "^7.6.17",
     "storybook": "^7.6.17",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9356,13 +9356,6 @@ sass-loader@^12.4.0:
     klona "^2.0.4"
     neo-async "^2.6.2"
 
-sb@^7.6.17:
-  version "7.6.17"
-  resolved "https://registry.npmjs.org/sb/-/sb-7.6.17.tgz"
-  integrity sha512-DfUp3vtZ4vmmId4itsgl00GIUCX1BiB+BwC2YQ4kU1aUppZV+3pk2H1ZUMSsTyzsEf+aTG65to7592Wrv4EhDg==
-  dependencies:
-    "@storybook/cli" "7.6.17"
-
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz"
@@ -9712,6 +9705,7 @@ streamx@^2.13.0, streamx@^2.15.0:
     bare-events "^2.2.0"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9786,6 +9780,7 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!-- 연관된 이슈 번호를 모두 작성해주세요
 ex) #이슈번호, #이슈번호 -->

- close #78 

## 📝 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능) -->

@trivago/prettier-plugin-sort-imports 설치 후 prettier-plugin-tailwindcss가 적용되지 않는 문제가 있었습니다. 공식문서를 찾아보니 해당 라이브러리는 마지막에 배치해서 로드시켜야만 적용이 되는 걸 알게되었습니다. [공식 문서](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)
![image](https://github.com/forfun-flowing/frontend/assets/115215178/0ddefc85-07c4-4d64-a09d-d57e5818b073)

```json5
// 변경 전
"plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],

// 변경 후
"plugins": ["@trivago/prettier-plugin-sort-imports", "prettier-plugin-tailwindcss"]
```
위와 같이 변경하고 나서 문제 없이 잘 동작하였습니다.
