### PR TITLE
로그인 후 적절한 가입 페이지로 매핑한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.0",
     "cookies-next": "^4.1.1",
     "framer-motion": "^10.18.0",
+    "jwt-decode": "^4.0.0",
     "next": "14.0.4",
     "next-themes": "^0.2.1",
     "react": "^18",

--- a/src/apis/member/apis.ts
+++ b/src/apis/member/apis.ts
@@ -1,0 +1,6 @@
+import http from '../config/instance';
+import type { MemberResponse } from './type';
+
+export const memberApi = {
+  getMember: async (id: string) => await http.get<MemberResponse>(`/members/${id}`),
+};

--- a/src/apis/member/index.ts
+++ b/src/apis/member/index.ts
@@ -1,0 +1,3 @@
+export * from './apis';
+export * from './queries';
+export * from './type';

--- a/src/apis/member/keys.ts
+++ b/src/apis/member/keys.ts
@@ -1,0 +1,3 @@
+export const queryKeys = {
+  getMember: (id: string) => ['getMember', id],
+} as const;

--- a/src/apis/member/queries.ts
+++ b/src/apis/member/queries.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { memberApi } from '.';
+import { queryKeys } from './keys';
+
+export const useGetMember = (memberId: string) => {
+  return useQuery({
+    queryKey: queryKeys.getMember(memberId!),
+    queryFn: () => memberApi.getMember(memberId!),
+    enabled: !!memberId,
+    select: (data) => {
+      const { status, profile } = data;
+
+      return { status, profile };
+    },
+  });
+};

--- a/src/apis/member/type.ts
+++ b/src/apis/member/type.ts
@@ -1,0 +1,18 @@
+import type {
+  AddressResponse,
+  ImageResponse,
+  SelfIntroResponse,
+  ValueResponse,
+} from '../profile/type';
+
+export type MemberResponse = {
+  id: string;
+  status: 'ACTIVE' | 'IN_SING_UP' | 'INACTIVE';
+  profile: {
+    id: string;
+    selfIntro: SelfIntroResponse;
+    address: AddressResponse;
+    valueResponses: ValueResponse[];
+    images: ImageResponse[];
+  };
+};

--- a/src/apis/profile/apis.ts
+++ b/src/apis/profile/apis.ts
@@ -1,0 +1,12 @@
+import http from '../config/instance';
+import type { SelfIntroRequest, ValueRequest } from './type';
+
+export const profileApi = {
+  postSelfIntro: async (memberId: string, formData: SelfIntroRequest) =>
+    await http.post(`/members/${memberId}/profiles/self-intro`, formData),
+
+  postValueResponse: async (memberId: string, formData: ValueRequest[]) =>
+    await http.post(`/members/${memberId}/profiles/value-responses`, {
+      valueResponses: formData,
+    }),
+};

--- a/src/apis/profile/index.ts
+++ b/src/apis/profile/index.ts
@@ -1,0 +1,3 @@
+export * from './apis';
+export * from './mutations';
+export * from './type';

--- a/src/apis/profile/mutations.ts
+++ b/src/apis/profile/mutations.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { decodeAccessToken } from '@/utils';
+
+import { profileApi } from './apis';
+import type { SelfIntroRequest, ValueRequest } from './type';
+
+export const usePostSelfIntro = () =>
+  useMutation({
+    mutationFn: (formData: SelfIntroRequest) =>
+      profileApi.postSelfIntro(decodeAccessToken(), formData),
+  });
+
+export const usePostValueResponse = () =>
+  useMutation({
+    mutationFn: (formData: ValueRequest[]) =>
+      profileApi.postValueResponse(decodeAccessToken(), formData),
+  });

--- a/src/apis/profile/type.ts
+++ b/src/apis/profile/type.ts
@@ -1,0 +1,36 @@
+export type SelfIntroResponse = {
+  nickname: string;
+  gender: boolean;
+  birth: string;
+  height: number;
+  bodyType: BodyType;
+  keywords: string;
+  mbti: string;
+};
+
+export type AddressResponse = {
+  id: number;
+  roadAddress: string;
+  sido: string;
+  sigungu: string;
+  bname: string;
+  zonecode: number;
+};
+
+export type ImageResponse = {
+  id: string;
+  name: string;
+  path: string;
+};
+
+export type ValueResponse = {
+  id: number;
+  question: string;
+  response: string;
+};
+
+export type ValueRequest = Omit<ValueResponse, 'question'>;
+
+export type SelfIntroRequest = SelfIntroResponse & {
+  address: Omit<AddressResponse, 'id'>;
+};

--- a/src/app/(mood)/join/components/Join1Context.tsx
+++ b/src/app/(mood)/join/components/Join1Context.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
 export type Join1ContextValue = {
   nickname: string;
-  birthday: string;
+  birth: string;
   gender: GenderType;
   keywords: string[];
   bodyType: BodyType | undefined;
@@ -21,7 +21,7 @@ export type Join1ContextValue = {
 
 const defaultValues: Join1ContextValue = {
   nickname: '',
-  birthday: '',
+  birth: '',
   gender: 'MALE',
   keywords: [],
   bodyType: undefined,

--- a/src/app/(mood)/join/funnels/JoinFunnel.tsx
+++ b/src/app/(mood)/join/funnels/JoinFunnel.tsx
@@ -10,7 +10,7 @@ import Step4Provider from './step4/components/Step4Context';
 import Step5 from './step5/Step5';
 
 export default function JoinFunnel() {
-  const { currentStep, Funnel, nextStep } = useFunnelContext();
+  const { currentStep, Funnel, nextStep, setStep } = useFunnelContext();
 
   return (
     <>
@@ -19,7 +19,7 @@ export default function JoinFunnel() {
       )}
       <Funnel>
         <Funnel.step name="1">
-          <Step1 nextStep={nextStep} />
+          <Step1 nextStep={nextStep} setStep={setStep} />
         </Funnel.step>
         <Funnel.step name="2">
           <div className="dark-mode absolute top-0 w-full pt-[57px]">

--- a/src/app/(mood)/join/funnels/step1/Step1.tsx
+++ b/src/app/(mood)/join/funnels/step1/Step1.tsx
@@ -1,13 +1,34 @@
 'use client';
 
 import Step1Image from '@public/svg/join-step1.svg';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
+import { type MemberResponse, useGetMember } from '@/apis/member';
 import { Button, ButtonWrapper } from '@/components/Button';
 import Spacing from '@/components/Spacing';
+import { decodeAccessToken } from '@/utils';
 
-import type { useFunnelContext } from '../../components/FunnelContext';
+import { useFunnelContext } from '../../components/FunnelContext';
 
-export default function Step1({ nextStep }: Pick<ReturnType<typeof useFunnelContext>, 'nextStep'>) {
+export default function Step1({
+  nextStep,
+  setStep,
+}: Pick<ReturnType<typeof useFunnelContext>, 'nextStep' | 'setStep'>) {
+  const router = useRouter();
+  const memberId = decodeAccessToken() || '';
+  const { data: profile } = useGetMember(memberId);
+
+  useEffect(() => {
+    if (profile?.status === 'ACTIVE') router.replace('/home');
+
+    if (profile?.status === 'INACTIVE') router.replace('/');
+
+    if (profile?.status === 'IN_SING_UP') {
+      setStep(getEmptyProfile(profile?.profile as MemberResponse['profile']));
+    }
+  }, [profile]);
+
   return (
     <>
       <div className="flex h-[85%] flex-col items-center justify-center">
@@ -21,4 +42,27 @@ export default function Step1({ nextStep }: Pick<ReturnType<typeof useFunnelCont
       </ButtonWrapper>
     </>
   );
+}
+
+function getEmptyProfile(profile: MemberResponse['profile']) {
+  for (const key in profile) {
+    const field = profile[key as keyof MemberResponse['profile']];
+
+    console.log(field);
+
+    if (!Object.keys(field) || (Array.isArray(field) && !field.length)) {
+      switch (key) {
+        case 'selfIntro':
+          return '1';
+        case 'address':
+          return '1';
+        case 'valueResponses':
+          return '3';
+        case 'images':
+          return '5';
+      }
+    }
+  }
+
+  return '1';
 }

--- a/src/app/(mood)/join/funnels/step1/Step1.tsx
+++ b/src/app/(mood)/join/funnels/step1/Step1.tsx
@@ -29,6 +29,8 @@ export default function Step1({
     }
   }, [profile]);
 
+  if (!profile) return null;
+
   return (
     <>
       <div className="flex h-[85%] flex-col items-center justify-center">

--- a/src/app/(mood)/join/funnels/step1/Step1.tsx
+++ b/src/app/(mood)/join/funnels/step1/Step1.tsx
@@ -50,8 +50,6 @@ function getEmptyProfile(profile: MemberResponse['profile']) {
   for (const key in profile) {
     const field = profile[key as keyof MemberResponse['profile']];
 
-    console.log(field);
-
     if (!Object.keys(field) || (Array.isArray(field) && !field.length)) {
       switch (key) {
         case 'selfIntro':

--- a/src/app/(mood)/join/funnels/step2/components/BirthdaySection.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/BirthdaySection.tsx
@@ -17,9 +17,9 @@ export default function BirthdaySection() {
     formState: { errors },
   } = useJoin1Context();
 
-  const birthday = useWatch({
+  const birth = useWatch({
     control,
-    name: 'birthday',
+    name: 'birth',
   });
   const gender = useWatch({
     control,
@@ -28,10 +28,10 @@ export default function BirthdaySection() {
 
   return (
     <>
-      <SectionLabel label="생년월일" isCheck={!errors.birthday?.message && gender && !!birthday} />
+      <SectionLabel label="생년월일" isCheck={!errors.birth?.message && gender && !!birth} />
       <div className="relative flex gap-x-2">
         <input
-          {...register('birthday', {
+          {...register('birth', {
             required: true,
             pattern: {
               value: /^\d{4}\.\d{2}\.\d{2}$/,
@@ -40,16 +40,16 @@ export default function BirthdaySection() {
             validate: (value) =>
               Number(value.slice(0, 4)) < 2006 || '2005년생 이후는 가입이 불가능합니다.',
           })}
-          id="birthday-input"
+          id="birth-input"
           placeholder="예시) 2024.01.25"
           className={cn(
             `h-[52px] w-full flex-[2] rounded-xl border border-gray-200 bg-transparent px-4 text-sm outline-none placeholder:text-base focus:border-primary-400 dark:border-gray-800 dark:text-white placeholder:dark:text-gray-700`,
           )}
         />
-        {errors.birthday?.message && (
+        {errors.birth?.message && (
           <p className="absolute top-full mt-2 inline-flex items-center gap-x-1 text-xs text-error">
             <WaringIcon />
-            {errors.birthday?.message}
+            {errors.birth?.message}
           </p>
         )}
         <div className="flex flex-1 gap-x-2">

--- a/src/app/(mood)/join/funnels/step2/components/BodyTypeSection.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/BodyTypeSection.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import CheckIcon from '@public/svg/check-16.svg';
 import { useWatch } from 'react-hook-form';
 
 import Spacing from '@/components/Spacing';

--- a/src/app/(mood)/join/funnels/step2/components/MbtiSection.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/MbtiSection.tsx
@@ -22,6 +22,7 @@ export default function MbtiSection() {
     <>
       <SectionLabel label="MBTI" isCheck={mbti.length === 4} />
       <button
+        type="button"
         onClick={() =>
           open(({ isOpen, close }) => (
             <MbtiBottomSheet useForm={useForm} isOpen={isOpen} onClose={close} />

--- a/src/app/(mood)/join/funnels/step2/components/MoodForm.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/MoodForm.tsx
@@ -2,6 +2,7 @@
 
 import { type SubmitHandler, useWatch } from 'react-hook-form';
 
+import { usePostSelfIntro } from '@/apis/profile/mutations';
 import { ButtonWrapper } from '@/components/Button';
 import Button from '@/components/Button/Button';
 import Input from '@/components/Input';
@@ -17,6 +18,7 @@ import RegionSection from './RegionSection';
 
 export default function MoodForm() {
   const { nextStep } = useFunnelContext();
+  const { mutate } = usePostSelfIntro();
   const {
     register,
     control,
@@ -34,12 +36,35 @@ export default function MoodForm() {
   });
 
   const handleOnSubmit: SubmitHandler<Join1ContextValue> = (data) => {
-    console.log(data);
+    const { gender, mbti, keywords, height, bodyType, address, birth, ...rest } = data;
+
+    const { zonecode, ...restAddress } = address;
+
+    if (!bodyType || !height || !address.zonecode) return;
+
+    mutate(
+      {
+        keywords: keywords.join(','),
+        mbti: mbti.join(''),
+        gender: gender === 'MALE',
+        height: +height,
+        bodyType: bodyType === '탄탄 슬림' ? '탄탄_슬림' : bodyType,
+        birth: birth.replaceAll('.', '-'),
+        address: {
+          zonecode: +address.zonecode,
+          ...restAddress,
+        },
+        ...rest,
+      },
+      {
+        onSuccess: () => nextStep(),
+      },
+    );
   };
 
   return (
     <>
-      <form id="mood" onSubmit={handleSubmit(handleOnSubmit)}>
+      <form onSubmit={handleSubmit(handleOnSubmit)}>
         <Input
           register={register('nickname', {
             required: true,
@@ -66,26 +91,24 @@ export default function MoodForm() {
         <RegionSection />
         <MykeywordSection />
         <MbtiSection />
+        <ButtonWrapper>
+          <Button
+            isDark
+            disabled={
+              !isValid ||
+              !dirtyFields.nickname ||
+              !dirtyFields.birth ||
+              !dirtyFields.bodyType ||
+              !dirtyFields.height ||
+              !dirtyFields.address ||
+              !dirtyFields.mbti ||
+              !keywords.length
+            }
+          >
+            다음
+          </Button>
+        </ButtonWrapper>
       </form>
-      <ButtonWrapper>
-        <Button
-          form="mood"
-          isDark
-          onClick={nextStep}
-          disabled={
-            !isValid ||
-            !dirtyFields.nickname ||
-            !dirtyFields.birthday ||
-            !dirtyFields.bodyType ||
-            !dirtyFields.height ||
-            !dirtyFields.address ||
-            !dirtyFields.mbti ||
-            !keywords.length
-          }
-        >
-          다음
-        </Button>
-      </ButtonWrapper>
     </>
   );
 }

--- a/src/app/(mood)/join/funnels/step2/components/MoodForm.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/MoodForm.tsx
@@ -40,7 +40,7 @@ export default function MoodForm() {
 
     const { zonecode, ...restAddress } = address;
 
-    if (!bodyType || !height || !address.zonecode) return;
+    if (!bodyType || !height) return;
 
     mutate(
       {

--- a/src/app/(mood)/join/funnels/step2/components/MyKeywordSection.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/MyKeywordSection.tsx
@@ -51,6 +51,7 @@ export default function MykeywordSection() {
         </ul>
       ) : (
         <button
+          type="button"
           className={cn(
             `h-[104px] w-full rounded-lg border border-dashed border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800`,
           )}

--- a/src/app/(mood)/join/funnels/step2/components/PostCodePopup.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/PostCodePopup.tsx
@@ -18,6 +18,7 @@ export default function PostCodePopup({ useForm, onClose }: PostCodePopupProps) 
 
   const handleComplete = async (data: Address) => {
     const { address, sido, zonecode, bname, sigungu } = data;
+
     setValue(
       'address',
       {

--- a/src/app/(mood)/join/funnels/step4/Step4.tsx
+++ b/src/app/(mood)/join/funnels/step4/Step4.tsx
@@ -22,7 +22,7 @@ export default function Step4({ nextStep }: Pick<ReturnType<typeof useFunnelCont
         bottomTitle="나의 가치관을 작성해주세요"
         subDescription="3개까지 선택 가능"
       />
-      <QuestionList />
+      <QuestionList nextStep={nextStep} />
     </div>
   );
 }

--- a/src/app/(sub)/auth/google/page.tsx
+++ b/src/app/(sub)/auth/google/page.tsx
@@ -21,6 +21,7 @@ export default function GoogleCallbackPage() {
     if (data) {
       const { accessToken, refreshToken } = data;
       setToken(accessToken, refreshToken);
+      setMemberId(decodeAccessToken());
     }
   }, [data]);
 
@@ -29,12 +30,6 @@ export default function GoogleCallbackPage() {
 
     if (profile?.status === 'ACTIVE') router.replace('/home');
   }, [profile]);
-
-  useEffect(() => {
-    if (decodeAccessToken()) {
-      setMemberId(decodeAccessToken()!);
-    }
-  }, [data]);
 
   return <></>;
 }

--- a/src/app/(sub)/auth/google/page.tsx
+++ b/src/app/(sub)/auth/google/page.tsx
@@ -1,16 +1,40 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useGetLogin } from '@/apis/auth';
+import { useGetMember } from '@/apis/member';
 import { BASE_DOMAIN } from '@/constants/environment';
+import { decodeAccessToken, setToken } from '@/utils';
 
 export default function GoogleCallbackPage() {
   const router = useRouter();
   const params = useSearchParams();
   const code = params.get('code') || '';
+  const [memberId, setMemberId] = useState(decodeAccessToken() || '');
   const { data } = useGetLogin(code, 'google', `${BASE_DOMAIN}/auth/google`);
+
+  const { data: profile } = useGetMember(memberId!);
+
+  useEffect(() => {
+    if (data) {
+      const { accessToken, refreshToken } = data;
+      setToken(accessToken, refreshToken);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (profile?.status === 'IN_SING_UP') router.replace('/join');
+
+    if (profile?.status === 'ACTIVE') router.replace('/home');
+  }, [profile]);
+
+  useEffect(() => {
+    if (decodeAccessToken()) {
+      setMemberId(decodeAccessToken()!);
+    }
+  }, [data]);
 
   return <></>;
 }

--- a/src/app/(sub)/auth/kakao/page.tsx
+++ b/src/app/(sub)/auth/kakao/page.tsx
@@ -21,6 +21,7 @@ export default function KakaoCallbackPage() {
     if (data) {
       const { accessToken, refreshToken } = data;
       setToken(accessToken, refreshToken);
+      setMemberId(decodeAccessToken());
     }
   }, [data]);
 
@@ -29,12 +30,6 @@ export default function KakaoCallbackPage() {
 
     if (profile?.status === 'ACTIVE') router.replace('/home');
   }, [profile]);
-
-  useEffect(() => {
-    if (decodeAccessToken()) {
-      setMemberId(decodeAccessToken()!);
-    }
-  }, [data]);
 
   return <></>;
 }

--- a/src/app/(sub)/auth/kakao/page.tsx
+++ b/src/app/(sub)/auth/kakao/page.tsx
@@ -1,23 +1,38 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useGetLogin } from '@/apis/auth';
+import { useGetMember } from '@/apis/member';
 import { BASE_DOMAIN } from '@/constants/environment';
-import { setToken } from '@/utils';
+import { decodeAccessToken, setToken } from '@/utils';
 
 export default function KakaoCallbackPage() {
   const router = useRouter();
   const params = useSearchParams();
   const code = params.get('code') || '';
+  const [memberId, setMemberId] = useState(decodeAccessToken() || '');
   const { data } = useGetLogin(code, 'kakao', `${BASE_DOMAIN}/auth/kakao`);
+
+  const { data: profile } = useGetMember(memberId);
 
   useEffect(() => {
     if (data) {
       const { accessToken, refreshToken } = data;
       setToken(accessToken, refreshToken);
-      router.replace('/join');
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (profile?.status === 'IN_SING_UP') router.replace('/join');
+
+    if (profile?.status === 'ACTIVE') router.replace('/home');
+  }, [profile]);
+
+  useEffect(() => {
+    if (decodeAccessToken()) {
+      setMemberId(decodeAccessToken()!);
     }
   }, [data]);
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,7 +25,7 @@
   }
 
   .body-layout {
-    @apply flex h-[var(--layout-min-h)] w-screen justify-center bg-white;
+    @apply flex h-[var(--layout-min-h)] w-screen justify-center bg-slate-50;
   }
 
   .main-layout {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -10,4 +10,4 @@ type CommonResponse<T = any> = {
 
 type GenderType = 'MALE' | 'FEMALE';
 
-type BodyType = '마름' | '탄탄 슬림' | '보통' | '통통' | '근육';
+type BodyType = '마름' | '탄탄 슬림' | '보통' | '통통' | '근육' | '탄탄_슬림';

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,19 +1,22 @@
 import { deleteCookie, getCookie, setCookie } from 'cookies-next';
+import { jwtDecode } from 'jwt-decode';
 
 import { TOKEN_KEYS } from '@/constants';
+
+type Payload = {
+  authority: string;
+  exp: number;
+  id: string;
+};
 
 const REFRESH_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000;
 // const ACCESS_EXPIRE_TIME = 60 * 60 * 1000;
 
-export const getToken = (): Promise<{ accessToken: string; refreshToken: string }> => {
+export const getToken = () => {
   const accessToken = getCookie(TOKEN_KEYS.accessToken);
   const refreshToken = getCookie(TOKEN_KEYS.refreshToken);
 
-  return new Promise((resolve) => {
-    if (accessToken && refreshToken) {
-      resolve({ accessToken, refreshToken });
-    }
-  });
+  return { accessToken, refreshToken };
 };
 
 export const setToken = (accessToken: string, refreshToken: string) => {
@@ -31,4 +34,16 @@ export const setToken = (accessToken: string, refreshToken: string) => {
 export const deleteToken = () => {
   deleteCookie(TOKEN_KEYS.accessToken);
   deleteCookie(TOKEN_KEYS.refreshToken);
+};
+
+export const decodeAccessToken = () => {
+  const { accessToken } = getToken();
+
+  if (accessToken) {
+    const payload: Payload = jwtDecode(accessToken);
+
+    return payload.id;
+  }
+
+  return '';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7424,6 +7424,11 @@ jsonfile@^6.0.1:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 - close #76 

## 📝 작업 내용
- 카카오/구글 콜백 페이지에서 토큰을 저장하고, 회원 정보를 조회해 status에 따라 적절한 페이지로 리다이렉션을 취해주었습니다.
- `IN_SIGN_UP`일 경우 /join 으로 이동하게 됩니다. Step1에서 빈 필드값을 순회해 적절한 Step을 setStep에 할당해주도록 합니다.
- Step2(자기소개 작성), Step4(나의 가치관) API 연동했습니다.

## 💬 리뷰어에게
브랜치에 실수로 이슈번호를 잘못 적었습니다...
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
