### PR TITLE
Step5 API 연동 & Step6 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'gyeol-imagebucket.s3.ap-northeast-2.amazonaws.com',
+      },
+    ],
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.17.1",
     "@tanstack/react-query-devtools": "^5.17.1",
     "axios": "^1.6.7",
+    "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.0",
     "cookies-next": "^4.1.1",
     "framer-motion": "^10.18.0",

--- a/src/apis/file/api.ts
+++ b/src/apis/file/api.ts
@@ -1,0 +1,15 @@
+import http from '../config/instance';
+import type { FileResponse } from './type';
+
+export const fileApi = {
+  postFile: async (file: File) => {
+    const form = new FormData();
+    form.append('file', file);
+
+    return await http.post<FileResponse>(`/files?object=profile`, form, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
+};

--- a/src/apis/file/mutations.ts
+++ b/src/apis/file/mutations.ts
@@ -1,0 +1,5 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { fileApi } from './api';
+
+export const usePostFile = () => useMutation({ mutationFn: fileApi.postFile });

--- a/src/apis/file/type.ts
+++ b/src/apis/file/type.ts
@@ -1,0 +1,5 @@
+export type FileResponse = {
+  id: string;
+  name: string;
+  path: string;
+};

--- a/src/apis/profile/apis.ts
+++ b/src/apis/profile/apis.ts
@@ -9,4 +9,9 @@ export const profileApi = {
     await http.post(`/members/${memberId}/profiles/value-responses`, {
       valueResponses: formData,
     }),
+
+  postProfileImage: async (memberId: string, fileIds: string[]) =>
+    await http.post(`/members/${memberId}/profiles/images`, {
+      fileIds,
+    }),
 };

--- a/src/apis/profile/mutations.ts
+++ b/src/apis/profile/mutations.ts
@@ -16,3 +16,8 @@ export const usePostValueResponse = () =>
     mutationFn: (formData: ValueRequest[]) =>
       profileApi.postValueResponse(decodeAccessToken(), formData),
   });
+
+export const usePostProfileImage = () =>
+  useMutation({
+    mutationFn: (fileIds: string[]) => profileApi.postProfileImage(decodeAccessToken(), fileIds),
+  });

--- a/src/app/(mood)/join/funnels/JoinFunnel.tsx
+++ b/src/app/(mood)/join/funnels/JoinFunnel.tsx
@@ -8,13 +8,14 @@ import Step3 from './step3/Step3';
 import Step4 from './step4/Step4';
 import Step4Provider from './step4/components/Step4Context';
 import Step5 from './step5/Step5';
+import Step6 from './step6/Step6';
 
 export default function JoinFunnel() {
   const { currentStep, Funnel, nextStep, setStep } = useFunnelContext();
 
   return (
     <>
-      {!(currentStep === '1' || currentStep === '3') && (
+      {!(currentStep === '1' || currentStep === '3' || currentStep === '6') && (
         <WaitingHeader isDark={currentStep === '2'} currentStep={currentStep} />
       )}
       <Funnel>
@@ -38,7 +39,7 @@ export default function JoinFunnel() {
           <Step5 nextStep={nextStep} />
         </Funnel.step>
         <Funnel.step name="6">
-          <div>Step 6</div>
+          <Step6 />
         </Funnel.step>
       </Funnel>
     </>

--- a/src/app/(mood)/join/funnels/step1/Step1.tsx
+++ b/src/app/(mood)/join/funnels/step1/Step1.tsx
@@ -64,5 +64,5 @@ function getEmptyProfile(profile: MemberResponse['profile']) {
     }
   }
 
-  return '1';
+  return '6';
 }

--- a/src/app/(mood)/join/funnels/step2/components/PostCodePopup.tsx
+++ b/src/app/(mood)/join/funnels/step2/components/PostCodePopup.tsx
@@ -41,7 +41,7 @@ export default function PostCodePopup({ useForm, onClose }: PostCodePopupProps) 
       <DaumPostcodeEmbed
         className="fixed inset-x-0 z-30 mx-auto mt-14 min-h-screen max-w-[430px]"
         onComplete={handleComplete}
-        shorthand={false}
+        shorthand={true}
         autoClose={false}
       />
     </Portal>

--- a/src/app/(mood)/join/funnels/step6/Step6.tsx
+++ b/src/app/(mood)/join/funnels/step6/Step6.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+
+import { useGetMember } from '@/apis/member';
+import { Button, ButtonWrapper } from '@/components/Button';
+import Spacing from '@/components/Spacing';
+import { calculateAge, decodeAccessToken } from '@/utils';
+
+export default function Step6() {
+  const memberId = decodeAccessToken();
+  const { data } = useGetMember(memberId);
+
+  return (
+    <div className="flex size-full flex-col items-center bg-gradient-to-br from-[#FFF0FC] to-[#FFE6DE] px-[53px]">
+      <Spacing size={48} />
+      <p className="text-xl font-bold">가입 승인을 대기 중이에요</p>
+      <Spacing size={12} />
+      <p className="whitespace-pre-wrap text-center text-sm font-medium text-gray-500">{`회원님의 정보를 위해\n플로잉에서 확인하고 있습니다`}</p>
+      <Spacing size={32} />
+      <div className="mx-[53px] flex size-full flex-col items-center justify-center rounded-2xl bg-white p-3.5">
+        <div className="relative size-full rounded-2xl">
+          <Image
+            src={data?.profile.images[0].path as string}
+            fill={true}
+            className="absolute rounded-2xl object-cover"
+            alt="profile"
+          />
+        </div>
+        <Spacing size={24} />
+        <p className="text-[22px] font-bold">{`${data?.profile.selfIntro.nickname}. ${calculateAge(
+          data?.profile.selfIntro.birth as string,
+        )}`}</p>
+        <Spacing size={16} />
+        <p className="text-sm text-gray-700">{`${data?.profile.address.sido} ${data?.profile.address.sigungu}`}</p>
+        <p className="text-sm text-gray-700">
+          {data?.profile.selfIntro.height} / {data?.profile.selfIntro.bodyType}
+        </p>
+      </div>
+      <Spacing size={72} />
+      <ButtonWrapper>
+        <Button>프로필 수정</Button>
+      </ButtonWrapper>
+    </div>
+  );
+}

--- a/src/utils/age.ts
+++ b/src/utils/age.ts
@@ -1,0 +1,12 @@
+export function calculateAge(birth: string) {
+  const today = new Date();
+  const birthDate = new Date(birth);
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const monthDiff = today.getMonth() - birthDate.getMonth();
+
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+    age--;
+  }
+
+  return age;
+}

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -2,7 +2,7 @@ import imageCompression from 'browser-image-compression';
 
 export const compressImage = async (file: File) => {
   const compressedImage = await imageCompression(file, {
-    maxSizeMB: 4,
+    maxSizeMB: 5,
     maxWidthOrHeight: 1920,
     useWebWorker: true,
   });

--- a/src/utils/compressImage.ts
+++ b/src/utils/compressImage.ts
@@ -1,0 +1,11 @@
+import imageCompression from 'browser-image-compression';
+
+export const compressImage = async (file: File) => {
+  const compressedImage = await imageCompression(file, {
+    maxSizeMB: 4,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  });
+
+  return new File([compressedImage], file.name, { type: file.type });
+};

--- a/src/utils/fileReader.ts
+++ b/src/utils/fileReader.ts
@@ -1,9 +1,0 @@
-export function convertFileToBase64(file: File) {
-  const reader = new FileReader();
-  reader.readAsDataURL(file);
-  return new Promise((resolve) => {
-    reader.onload = () => {
-      resolve(reader.result);
-    };
-  });
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cn';
 export * from './address';
-export * from './fileReader';
 export * from './token';
+export * from './age';
+export * from './compressImage';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,6 +4316,13 @@ browser-assert@^1.2.1:
   resolved "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz"
   integrity sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browserify-aes@^1.0.4, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
@@ -10514,6 +10521,11 @@ uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #82 

## 📝 작업 내용

- Step5 프로필 사진 업로드 API를 연동했습니다.
기존에는 최대 용량이 1MB여서 용량이 초과할 경우 서버에서 에러를 반환하는 문제가 있었습니다. (최대 용량 5MB로 수정 될 예정입니다)
API를 요청 보내기 전`broswer-image-compression` 라이브러리를 통해 한단계 압축합니다.
- Step6 페이지를 구현했습니다.

![화면 기록 2024-03-14 오후 7 38 10](https://github.com/forfun-flowing/frontend/assets/48711263/1848e3d5-0709-449e-8d07-cf240084b733)
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능) -->

## 💬 리뷰어에게
Step6에서 이미지 화질이 깨지는데 저화질 사진을 첨부해서 신경 안쓰셔도 될 것 같습니다
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
