### PR TITLE
피드 필터 성별 기본값 이성만 보이도록 설정

### DIFF
--- a/src/apis/member/queries.ts
+++ b/src/apis/member/queries.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { memberApi } from '.';
 import { queryKeys } from './keys';
@@ -14,3 +14,14 @@ export const useGetMember = (memberId: string) => {
     },
   });
 };
+
+export const useGetMemberProfile = (memberId: string) =>
+  useQuery({
+    queryKey: queryKeys.getMember(memberId),
+    queryFn: () => memberApi.getMember(memberId),
+    select: (data) => {
+      const { profile } = data;
+
+      return profile;
+    },
+  });

--- a/src/app/(main)/feed/page.tsx
+++ b/src/app/(main)/feed/page.tsx
@@ -2,8 +2,10 @@
 
 import { Suspense } from 'react';
 
+import { useGetMemberProfile } from '@/apis/member';
 import { TabProvider } from '@/components/TabBar';
 import BottomTabBar from '@/components/TabBar/BottomTabBar';
+import { decodeAccessToken } from '@/utils';
 
 import FeedFilterBar from './components/FeedFilterBar';
 import FeedHeader from './components/FeedHeader';
@@ -12,12 +14,15 @@ import FeedTabs from './components/FeedTabs';
 import FeedFilterProvider from './components/Filter/FeedFilterContext';
 
 export default function Feed() {
+  const { data: myProfile } = useGetMemberProfile(decodeAccessToken());
+  if (myProfile === undefined) return null;
+
   return (
     <Suspense>
       <TabProvider initialValue="recommend">
         <FeedHeader />
         <FeedTabs />
-        <FeedFilterProvider>
+        <FeedFilterProvider myProfile={myProfile}>
           <FeedFilterBar />
           <FeedList />
         </FeedFilterProvider>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#152 

## 📝 작업 내용

피드 필터 성별 기본값 이성만 보이도록 설정했습니다.

## 💬 리뷰어에게

기존에 있던 useSuspenseQuery를 사용한 useGetMember로 ContextProvider안에서 profile데이터 불러오는게 잘 해결이 안돼서 일단 useQuery써서 하나 더 만들어버렸습니다..